### PR TITLE
Feature/bridge

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -8,6 +8,7 @@ idf_component_register(SRCS "main.c"
                             "nv_storage.c"
                             "ssdp.c"
                             "setting_items.c"
+                            "bridge.c"
                         INCLUDE_DIRS "."
                         EMBED_TXTFILES
                         frontend/index.html

--- a/main/bridge.c
+++ b/main/bridge.c
@@ -1,0 +1,87 @@
+#include "bridge.h"
+
+#include "esp_check.h"
+#include "serial.h"
+#include "setting_items.h"
+#include "tcp_client.h"
+#include "tcp_server.h"
+
+static const char *TAG = "bridge";
+
+bridge_mode_t bridge_mode = 0;
+bool bridge_ready = false;
+bool bridge_modbus = false;
+
+void process_data_from_serial(uint8_t *data, uint8_t len)
+{
+    if (!bridge_ready) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "received %d bytes from serial", len);
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, data, len, ESP_LOG_INFO);
+
+    if (bridge_mode == BRIDGE_MODE_SERVER) {
+        tcp_server_send(data, len);
+    } else if (bridge_mode == BRIDGE_MODE_CLIENT) {
+        tcp_client_send(data, len);
+    }
+}
+
+void process_data_from_tcp(uint8_t *data, uint8_t len)
+{
+    if (!bridge_ready) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "received %d bytes from tcp", len);
+    ESP_LOG_BUFFER_HEX_LEVEL(TAG, data, len, ESP_LOG_INFO);
+
+    serial_send(data, len);
+}
+
+esp_err_t bridge_init(void)
+{
+    serial_config_t serial_config = {0};
+    int bridge_port = 0;
+    uint32_t bridge_ip = 0;
+
+    ESP_RETURN_ON_ERROR(setting_items_read_raw("bridge_mode", &bridge_mode, SETTING_ITEM_TYPE_NUM),
+                        TAG, "error reading bridge_mode");
+    ESP_RETURN_ON_ERROR(setting_items_read_raw("bridge_port", &bridge_port, SETTING_ITEM_TYPE_NUM),
+                        TAG, "error reading bridge_port");
+    ESP_RETURN_ON_ERROR(setting_items_read_raw("bridge_ip", &bridge_ip, SETTING_ITEM_TYPE_NUM), TAG,
+                        "error reading bridge_ip");
+
+    ESP_RETURN_ON_ERROR(
+        setting_items_read_raw("baudrate", &serial_config.baudrate, SETTING_ITEM_TYPE_NUM), TAG,
+        "error reading baudrate");
+    ESP_RETURN_ON_ERROR(
+        setting_items_read_raw("baudrate", &serial_config.baudrate, SETTING_ITEM_TYPE_NUM), TAG,
+        "error reading baudrate");
+    ESP_RETURN_ON_ERROR(
+        setting_items_read_raw("stopbits", &serial_config.stopbits, SETTING_ITEM_TYPE_NUM), TAG,
+        "error reading stopbits");
+    ESP_RETURN_ON_ERROR(
+        setting_items_read_raw("parity", &serial_config.parity, SETTING_ITEM_TYPE_NUM), TAG,
+        "error reading parity");
+    ESP_RETURN_ON_ERROR(
+        setting_items_read_raw("databits", &serial_config.databits, SETTING_ITEM_TYPE_NUM), TAG,
+        "error reading databits");
+
+    if (bridge_mode == BRIDGE_MODE_SERVER) {
+        ESP_RETURN_ON_ERROR(tcp_server_init(bridge_port, process_data_from_tcp), TAG,
+                            "error initializing tcp server");
+    } else if (bridge_mode == BRIDGE_MODE_CLIENT) {
+        ESP_RETURN_ON_ERROR(tcp_client_init(bridge_ip, bridge_port, process_data_from_tcp), TAG,
+                            "error initializing tcp client");
+    }
+
+    ESP_RETURN_ON_ERROR(serial_init(&serial_config, process_data_from_serial), TAG,
+                        "error initializing serial");
+
+    bridge_ready = true;
+    ESP_LOGI(TAG, "initialized");
+
+    return ESP_OK;
+}

--- a/main/bridge.h
+++ b/main/bridge.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "esp_err.h"
+
+esp_err_t bridge_init(void);

--- a/main/main.c
+++ b/main/main.c
@@ -1,5 +1,6 @@
 #include <string.h>
 
+#include "bridge.h"
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_mac.h"
@@ -62,7 +63,8 @@ void app_main(void)
     char default_hostname[SETTING_ITEM_MAX_STR_LEN] = {0};
     uint8_t mac[6];
     esp_read_mac(mac, ESP_MAC_ETH);
-    snprintf(default_hostname, SETTING_ITEM_MAX_STR_LEN, "%s-%02X%02X%02X", BASE_HOSTNAME, mac[3], mac[4], mac[5]);
+    snprintf(default_hostname, SETTING_ITEM_MAX_STR_LEN, "%s-%02X%02X%02X", BASE_HOSTNAME, mac[3],
+             mac[4], mac[5]);
     ESP_ERROR_CHECK(setting_items_init(default_hostname, &setting_item_iface));
 
     char hostname[SETTING_ITEM_MAX_STR_LEN] = {0};
@@ -107,4 +109,6 @@ void app_main(void)
 
     ssdp_config_t ssdp_config = NULL;
     ESP_ERROR_CHECK(http_server_init(&ssdp_config));
+
+    ESP_ERROR_CHECK(bridge_init());
 }

--- a/main/setting_items.c
+++ b/main/setting_items.c
@@ -182,6 +182,7 @@ static bool string2ip(const char *str, uint32_t *ip)
 {
     // Дополнительная ячейка нужна для проверки наличия лишнего байта ip адреса
     int ip_arr[IP_ADDR_NUM + 1] = {0};
+    // Строка преобразуется в сетевом порядке байтов
     if (sscanf(str, "%d.%d.%d.%d.%d", &ip_arr[3], &ip_arr[2], &ip_arr[1], &ip_arr[0], &ip_arr[4]) ==
         IP_ADDR_NUM) {
         for (int i = 0; i < IP_ADDR_NUM; i++) {
@@ -199,6 +200,31 @@ static bool string2ip(const char *str, uint32_t *ip)
     } else {
         return false;
     }
+}
+
+static bool bridge_mode2string(bridge_mode_t mode, char *str)
+{
+    switch (mode) {
+        case BRIDGE_MODE_SERVER:
+            strcpy(str, "tcps-serial");
+            return true;
+        case BRIDGE_MODE_CLIENT:
+            strcpy(str, "tcpc-serial");
+            return true;
+    }
+    return false;
+}
+
+static bool string2bridge_mode(const char *str, bridge_mode_t *mode)
+{
+    if (strcmp(str, "tcps-serial") == 0) {
+        *mode = BRIDGE_MODE_SERVER;
+        return true;
+    } else if (strcmp(str, "tcpc-serial") == 0) {
+        *mode = BRIDGE_MODE_CLIENT;
+        return true;
+    }
+    return false;
 }
 
 static bool save_wifi_mode(const char *key, const void *value)
@@ -338,6 +364,30 @@ static bool read_parity(const char *key, void *value)
         return false;
     }
     if (parity2string(parity, value) == false) {
+        return false;
+    }
+    return true;
+}
+
+static bool save_bridge_mode(const char *key, const void *value)
+{
+    bridge_mode_t mode;
+    if (string2bridge_mode(value, &mode)) {
+        if (iface.save_num(key, (uint32_t)mode) != 0) {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool read_bridge_mode(const char *key, void *value)
+{
+    uint32_t mode = 0;
+    if (iface.read_num(key, &mode) != 0) {
+        return false;
+    }
+    if (bridge_mode2string((bridge_mode_t)mode, value) == false) {
         return false;
     }
     return true;
@@ -734,12 +784,12 @@ const setting_item_t setting_items[] = {
         .read_from_storage_raw = read_raw_value,
     },
     {
-        .key = "bridge_mode",  // TODO: сделать валидатор для режима моста
+        .key = "bridge_mode",
         .default_value = "tcps-serial",
-        .type_in_storage = SETTING_ITEM_TYPE_STR,
+        .type_in_storage = SETTING_ITEM_TYPE_NUM,
         .type_in_json = SETTING_ITEM_TYPE_STR,
-        .save_to_storage = save_string_value,
-        .read_from_storage = read_string_value,
+        .save_to_storage = save_bridge_mode,
+        .read_from_storage = read_bridge_mode,
         .read_from_storage_raw = read_raw_value,
     },
     {

--- a/main/setting_items.h
+++ b/main/setting_items.h
@@ -42,6 +42,11 @@ typedef struct {
     read_from_storage_raw read_from_storage_raw;
 } setting_item_t;
 
+typedef enum {
+    BRIDGE_MODE_SERVER = 1,
+    BRIDGE_MODE_CLIENT,
+} bridge_mode_t;
+
 int setting_items_init(char * def_hostname, setting_item_iface_t *setting_item_iface);
 int setting_items_set_defaults();
 // Чтение данных из хранилища, без преобразования

--- a/main/tcp_client.c
+++ b/main/tcp_client.c
@@ -1,43 +1,47 @@
 // #include "sdkconfig.h"
-#include <string.h>
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
-#include <sys/socket.h>
-#include <errno.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include "esp_netif.h"
-#include "esp_log.h"
 #include "tcp_client.h"
 
-#define RX_BUFFER_SIZE 1024
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define RX_BUFFER_SIZE             1024
 #define TCP_CLIENT_TASK_STACK_SIZE 4096
-#define TCP_CLIENT_TASK_PRIORITY 5
+#define TCP_CLIENT_TASK_PRIORITY   5
 
 static const char *TAG = "tcp-client";
 
 static int sock = -1;
 static int port = 0;
-static char ip[20] = {0};
 tcpc_receive_handler_t tcp_client_receive_handler = NULL;
 
 static void tcp_client_task(void *pvParameters)
 {
     char rx_buffer[RX_BUFFER_SIZE];
+    uint32_t ip = *((uint32_t *)pvParameters);
 
     while (1) {
         while (1) {
             struct sockaddr_in dest_addr;
-            inet_pton(AF_INET, ip, &dest_addr.sin_addr);
+            dest_addr.sin_addr.s_addr = ip;
             dest_addr.sin_family = AF_INET;
             dest_addr.sin_port = htons(port);
 
-            sock =  socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+            sock = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
             if (sock < 0) {
                 ESP_LOGE(TAG, "Unable to create socket: errno %d", errno);
                 break;
             }
-            ESP_LOGI(TAG, "Socket created, connecting to %s:%d", ip, port);
+            char ip_str[INET_ADDRSTRLEN];
+            inet_ntop(AF_INET, &dest_addr.sin_addr, ip_str, sizeof(ip_str));
+            ESP_LOGI(TAG, "Socket created, connecting to %s:%d", ip_str, port);
 
             int err = connect(sock, (struct sockaddr *)&dest_addr, sizeof(dest_addr));
             if (err != 0) {
@@ -52,13 +56,13 @@ static void tcp_client_task(void *pvParameters)
                 if (len < 0) {
                     ESP_LOGE(TAG, "recv failed: errno %d", errno);
                     break;
-                }
-                else {
+                } else {
                     ESP_LOGD(TAG, "Received %d bytes", len);
                     ESP_LOG_BUFFER_HEX_LEVEL(TAG, rx_buffer, len, ESP_LOG_DEBUG);
                     tcp_client_receive_handler((uint8_t *)rx_buffer, len);
                 }
             }
+            ESP_LOGI(TAG, "Disconnected from server");
         }
         if (sock != -1) {
             ESP_LOGE(TAG, "Shutting down socket and restarting...");
@@ -68,16 +72,17 @@ static void tcp_client_task(void *pvParameters)
     }
 }
 
-esp_err_t tcp_client_init(char *host_ip, int host_port, tcpc_receive_handler_t tcpc_receive_handler)
+esp_err_t tcp_client_init(uint32_t host_ip, uint16_t host_port,
+                          tcpc_receive_handler_t tcpc_receive_handler)
 {
     if (tcpc_receive_handler == NULL) {
         ESP_LOGE(TAG, "tcpc_receive_handler is NULL");
         return ESP_ERR_INVALID_ARG;
     }
     port = host_port;
-    strcpy(ip, host_ip);
     tcp_client_receive_handler = tcpc_receive_handler;
-    xTaskCreate(tcp_client_task, "tcp_client", TCP_CLIENT_TASK_STACK_SIZE, NULL, TCP_CLIENT_TASK_PRIORITY, NULL); // TODO: check stack size
+    xTaskCreate(tcp_client_task, "tcp_client", TCP_CLIENT_TASK_STACK_SIZE, &host_ip,
+                TCP_CLIENT_TASK_PRIORITY, NULL);  // TODO: check stack size
     return ESP_OK;
 }
 

--- a/main/tcp_client.h
+++ b/main/tcp_client.h
@@ -5,5 +5,5 @@
 
 typedef void(*tcpc_receive_handler_t)(uint8_t*, uint8_t);
 
-esp_err_t tcp_client_init(char *host_ip, int host_port, tcpc_receive_handler_t tcpc_receive_handler);
+esp_err_t tcp_client_init(uint32_t host_ip, uint16_t host_port, tcpc_receive_handler_t tcpc_receive_handler);
 esp_err_t tcp_client_send(uint8_t *data, uint8_t len);

--- a/unittests/setting_items_test.c
+++ b/unittests/setting_items_test.c
@@ -176,6 +176,40 @@ int ip_test(void)
     return TEST_OK;
 }
 
+int bridge_test(void)
+{
+    char* valid_test_bridge_mode[] = {"tcps-serial", "tcpc-serial"};
+    char* invalid_test_bridge_mode[] = {"tcps", "tcpc", "serial", "tcps-serial-serial", "tcpc-serial-serial"};
+
+    for (int i = 0; i < sizeof(valid_test_bridge_mode) / sizeof(valid_test_bridge_mode[0]); i++) {
+        char* expected_str = valid_test_bridge_mode[i];
+        if (setting_items_save("bridge_mode", expected_str) != 0) {
+            TEST_FAILED("Failed to save bridge_mode \"%s\"", expected_str);
+            return TEST_ERR;
+        }
+        char got_str[SETTING_ITEM_MAX_STR_LEN] = {0};
+        if (setting_items_read("bridge_mode", got_str)) {
+            TEST_FAILED("Failed to read bridge_mode");
+            return TEST_ERR;
+        }
+        if (strcmp(expected_str, got_str) != 0) {
+            TEST_FAILED("Expected %s, got %s", expected_str, got_str);
+            return TEST_ERR;
+        }
+    }
+
+    for (int i = 0; i < sizeof(invalid_test_bridge_mode) / sizeof(invalid_test_bridge_mode[0]); i++) {
+        char* invalid_str = invalid_test_bridge_mode[i];
+        if (setting_items_save("bridge_mode", invalid_str) == 0) {
+            TEST_FAILED("Saved invalid bridge_mode \"%s\"", invalid_str);
+            return TEST_ERR;
+        }
+    }
+
+    TEST_PASSED();
+    return TEST_OK;
+}
+
 int main(void)
 {
     rams_init();
@@ -210,6 +244,9 @@ int main(void)
         return -1;
     }
     if (ip_test() != 0) {
+        return -1;
+    }
+    if (bridge_test() != 0) {
         return -1;
     }
 


### PR DESCRIPTION
Реализована основная логика передачи пакетов TCP-server <--> Serial, TCP-client <--> Serial. Для начала без анализа пакетов и их преобразования Modbus-TCP <--> Modbus-RTU. Добавлен тест режима моста. Небольшие изменения в TCP-client, а именно - функция инициализации теперь принимает ip в uint32_t, а не строкой, так как во флеше хранится uint32_t. [Задача](https://wirenboard.youtrack.cloud/issue/FW-668/Realizovat-osnovnuyu-logiku-mosta-MGE) в YouTrack.