### PR TITLE
Add TWDT panic on timeout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-09-17 Ilia Skochilov <ilia.skochilov@wirenboard.com>
+    * version:  1.0.0-rc7
+    * added:    Task Watchdog Timer panic on timeout (reset system)
+
 2025-09-17 Maxim Toropov <maxim.toropov@wirenboard.com>
 
     * version:  1.0.0-rc6

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -40,3 +40,6 @@ CONFIG_LWIP_STATS=y
 # Only for debug purposes
 # TODO: Delete it in production release
 CONFIG_EFUSE_VIRTUAL=y
+
+# Task Watchdog Timer panic on timeout (reset system)
+CONFIG_ESP_TASK_WDT_PANIC=y


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавлена опция конфигурации для перезагрузки устройства при срабатывании TWDT.

___________________________________
**Что поменялось для пользователей:**
При зависании задач более, чем на 5с, происходит перезагрузка устройства.

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
Проверял имитацией зависания задачи.

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Не требуется.
