### PR TITLE
Fix MIO reset control

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
+    * version:  1.0.0-rc12
+    * fix:      MIO reset control (init GPIO expander and MIO control as quickly as posible)
+
+2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
 
     * version:  1.0.0-rc11
     * added:    apply settings without restart

--- a/main/main.c
+++ b/main/main.c
@@ -94,20 +94,27 @@ static inline void print_setting_items(void)
 
 void app_main(void)
 {
+    #if (!QEMU_BUILD)
+        gpio_expander_init(&gpio_expander);
+        rs485_control_init(gpio_expander);
+        mio_control_init(gpio_expander);
+    #endif // QEMU_BUILD
+
     ESP_ERROR_CHECK(sys_info_init());
     ESP_ERROR_CHECK(nvs_init());
     ESP_ERROR_CHECK(setting_items_init());
+
+    #if (!QEMU_BUILD)
+        update_io_bus_control();
+    #endif // QEMU_BUILD
+
     ESP_ERROR_CHECK(network_init());
     ESP_ERROR_CHECK(http_server_init());
 
     print_setting_items();
 
     #if (!QEMU_BUILD)
-        gpio_expander_init(&gpio_expander);
-        rs485_control_init(gpio_expander);
         update_rs485_control();
-        mio_control_init(gpio_expander);
-        update_io_bus_control();
         indication_init(gpio_expander);
         indication_status_led_blink(STATUS_LED_REGULAR_BLINK_PERIOD_MS);
         config_button_init();


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Исправлено управление сбросом MIO - инициализация расширителя портов и выдача сигнала сброса производятся как можно быстрее после запуска программы.

https://wirenboard.youtrack.cloud/issue/FW-1120/Problema-s-lishnimi-sbrosami-MIO-pri-vklyuchenii-pitaniya

___________________________________
**Что поменялось для пользователей:**
Ничего, проблема была на производстве.

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
На столе, смотрел лог. анализатором (от включения питания 730 мс до спада #RST и 860 мс до подъема #RST, т.е. через 860 мс после подачи питания на MGE начинает работать MIO).
Также проверял Гена на производственном стенде, проблем не возникало (там где они были до этого фикса)

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Не покрывал, до покрытия модуля main еще не добрались, покрываем тестами проекта в рамках отдельной задачи.
