### PR TITLE
Release prepare

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,12 @@
-2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
+2025-10-02 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.0-rc13
     * rework:   debug logs control (separate module)
     * added:    disabled virtual eFuses, now real eFuses used
     * added:    enabled default WiFi AP password
     * improve:  enabled binary size compiler optimization
+    * fix:      i2c_master warning on pull-ups
+    * fix:      apply new settings on factory reset triggered by config button
+    * fix:      WiFi STA initial connection to AP (appeared after disabling logs)
 
 2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.0-rc12

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
+    * version:  1.0.0-rc13
+    * rework:   debug logs control (separate module)
+    * added:    disabled virtual eFuses, now real eFuses used
+    * added:    enabled default WiFi AP password
+    * improve:  enabled binary size compiler optimization
+
+2025-10-01 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.0-rc12
     * fix:      MIO reset control (init GPIO expander and MIO control as quickly as posible)
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -25,7 +25,8 @@ set(COMPONENT_SRCS "main.c"
                    "bridge/rs485_stats.c"
                    "wb_app_desc/wb_app_desc.c"
                    "settings_update.c"
-                   "settings_save_timer.c")
+                   "settings_save_timer.c"
+                   "debug_log.c")
 
 # Conditionally add files based on build type
 if(CONFIG_ETH_USE_OPENETH)

--- a/main/auth.c
+++ b/main/auth.c
@@ -10,8 +10,6 @@
 #include "array_size.h"
 
 
-#define AUTH_DEBUG_LOG_ENABLE   0               // TODO: Возможно, вынести в настройки
-
 #define MAX_SESSIONS            10
 #define COOKIE_MAX_LEN          (11 + 10 + 1)   // "session_id=" + uint32_max + '\0'
 
@@ -184,10 +182,6 @@ static inline bool set_cookie_session_id(httpd_req_t *req, uint32_t session_id, 
 
 esp_err_t auth_init(void)
 {
-    if (AUTH_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     esp_reset_reason_t reset_reason = esp_reset_reason();
     ESP_LOGD(TAG, "Reset reason: %d", reset_reason);
 

--- a/main/bridge/bridge.c
+++ b/main/bridge/bridge.c
@@ -18,8 +18,6 @@
 #include <sys/socket.h>
 
 
-#define BRIDGE_DEBUG_LOG_ENABLE       0           // TODO: Возможно, вынести в настройки
-
 #define SERIAL_PORT_NUM_1             1
 #define SERIAL_INPUT_PIN_1            GPIO_NUM_9
 #define SERIAL_OUTPUT_PIN_1           GPIO_NUM_10
@@ -172,10 +170,6 @@ static esp_err_t read_tcp_bridge_config(const int index, bridge_mode_t* mode, ui
 
 esp_err_t bridge_init(void)
 {
-    if (BRIDGE_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     // Start RS485 busy monitor task and init error percentage statistics
     rs485_busy_monitor_init();
     rs485_stats_init();

--- a/main/bridge/modbus_tcp.c
+++ b/main/bridge/modbus_tcp.c
@@ -9,8 +9,6 @@
 #include "bridge.h"
 
 
-#define MODBUS_TCP_DEBUG_LOG_ENABLE         0               // TODO: Возможно, вынести в настройки
-
 #define MODBUS_TCP_TASK_STACK_SIZE          3072            // Размер стека каждой задачи
 #define MODBUS_TCP_TASK_PRIORITY            4               // Приоритет задач
 #define MODBUS_TCP_MAX_TASK_COUNT           BRIDGES_COUNT   // Максимальное количество задач (портов)
@@ -366,11 +364,6 @@ esp_err_t modbus_tcp_init_port(unsigned index, serial_config_t *config,
     if (mode != BRIDGE_MODE_SERVER) {
         ESP_LOGE(TAG, "Port[%u]: Unsupported mode: %d, only Modbus TCP Server mode (%d) is suppurted", index + 1, mode, BRIDGE_MODE_SERVER);
         return ESP_ERR_INVALID_ARG;
-    }
-
-    if (MODBUS_TCP_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-        esp_log_level_set("modbus_helpers", ESP_LOG_DEBUG);
     }
 
     if (index >= MODBUS_TCP_MAX_TASK_COUNT) {

--- a/main/bridge/serial.c
+++ b/main/bridge/serial.c
@@ -14,8 +14,6 @@
 #include "esp_bit_defs.h"
 
 
-#define SERIAL_DEBUG_LOG_ENABLE         0           // TODO: Возможно, вынести в настройки
-
 // буфер должен быть больше, чем максимальный размер пакета modbus + байты арбитража быстрого modbus
 // но, так как устройство может работать в режиме "прозрачного" шлюза, то размер буфера стоит выбирать с запасом
 // при переполнении буфера возникнет событие UART_BUFFER_FULL
@@ -108,10 +106,6 @@ static void uart_event_task(void *pvParameters)
 
 serial_desc_t* serial_init(serial_config_t *serial_config, serial_receive_handler_t serial_receive_handler)
 {
-    if (SERIAL_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (serial_config == NULL) {
         ESP_LOGE(TAG, "Serial config pointer is NULL");
         return NULL;

--- a/main/bridge/tcp_client.c
+++ b/main/bridge/tcp_client.c
@@ -11,7 +11,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#define TCP_CLIENT_DEBUG_LOG_ENABLE     1           // TODO: Возможно, вынести в настройки
 
 #define KEEPALIVE_IDLE                  5
 #define KEEPALIVE_INTERVAL              5
@@ -27,7 +26,7 @@
 #define EVENT_TASK_EXIT_REQ             BIT8
 
 
-static const char *TAG = "tcp-client";
+static const char *TAG = "tcp_client";
 
 
 static inline bool delay_until_exit_req(tcp_desc_t *desc, TickType_t ticks)
@@ -191,10 +190,6 @@ static void tcp_client_task(void *pvParameters)
 esp_err_t tcp_client_init(uint32_t host_ip, uint16_t host_port,
                           tcp_receive_handler_t tcpc_receive_handler, tcp_desc_t **out_desc)
 {
-    if (TCP_CLIENT_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (tcpc_receive_handler == NULL) {
         ESP_LOGE(TAG, "tcpc_receive_handler is NULL");
         return ESP_ERR_INVALID_ARG;

--- a/main/bridge/tcp_server.c
+++ b/main/bridge/tcp_server.c
@@ -5,7 +5,6 @@
 #include "freertos/task.h"
 #include "lwip/sockets.h"
 
-#define TCP_SERVER_DEBUG_LOG_ENABLE     0           // TODO: Возможно, вынести в настройки
 
 #define KEEPALIVE_IDLE                  5
 #define KEEPALIVE_INTERVAL              5
@@ -19,7 +18,7 @@
 #define EVENT_TASK_EXIT_REQ             BIT8
 
 
-static const char *TAG = "tcp-server";
+static const char *TAG = "tcp_server";
 
 
 static inline bool check_task_exit_req(tcp_desc_t *desc)
@@ -189,10 +188,6 @@ static void tcp_server_task(void *pvParameters)
 
 esp_err_t tcp_server_init(int port, tcp_receive_handler_t tcps_receive_handler, tcp_desc_t **out_desc)
 {
-    if (TCP_SERVER_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (tcps_receive_handler == NULL) {
         ESP_LOGE(TAG, "tcps_receive_handler is NULL");
         return ESP_ERR_INVALID_ARG;

--- a/main/bridge/transparent_tcp.c
+++ b/main/bridge/transparent_tcp.c
@@ -9,8 +9,6 @@
 #include "bridge.h"
 
 
-#define TRANSPARENT_TCP_DEBUG_LOG_ENABLE    1               // TODO: Возможно, вынести в настройки
-
 #define TRANSPARENT_TCP_MAX_TASK_COUNT      BRIDGES_COUNT   // Максимальное количество задач (портов)
 
 
@@ -129,10 +127,6 @@ esp_err_t transparent_tcp_init_port(unsigned index, serial_config_t *config,
                                     bridge_mode_t mode, int port, uint32_t ip,
                                     serial_desc_t **serial_desc, tcp_desc_t **tcp_desc)
 {
-    if (TRANSPARENT_TCP_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (index >= TRANSPARENT_TCP_MAX_TASK_COUNT) {
         ESP_LOGE(TAG, "Port[%u]: Port number out of range", index + 1);
         return ESP_ERR_INVALID_ARG;

--- a/main/config.h
+++ b/main/config.h
@@ -27,7 +27,7 @@
 #define DEFAULT_ETH_DHCPC           "true"
 
 #define DEFAULT_WIFI_MODE           WIFI_MODE_AP_STR
-#define DEFAULT_WIFI_AUTH           WIFI_AUTH_OPEN_STR // TODO: в релизе поменять на WIFI_AUTH_WPA2_PSK_STR. Пароль будет печататься на наклейке.
+#define DEFAULT_WIFI_AUTH           WIFI_AUTH_WPA2_PSK_STR
 #define DEFAULT_AP_IP_STATIC        "192.168.5.1"
 #define DEFAULT_AP_MASK_STATIC      "255.255.255.0"
 #define DEFAULT_AP_GW_STATIC        "192.168.5.1"

--- a/main/debug_log.c
+++ b/main/debug_log.c
@@ -1,0 +1,72 @@
+#include <stdbool.h>
+#include <string.h>
+#include "esp_log.h"
+#include "debug_log.h"
+#include "array_size.h"
+
+#if (DEBUG_LOG_ENABLE)
+
+    typedef struct {
+        const char* tag;
+        bool enabled;
+    } cfg_elem_t;
+
+    static const cfg_elem_t debug_log_config[] = {
+        {.tag = "main",                 .enabled = true},
+        {.tag = "auth",                 .enabled = false},
+        {.tag = "gpio_expander",        .enabled = false},
+        {.tag = "nv_storage",           .enabled = false},
+        {.tag = "setting_items",        .enabled = false},
+        {.tag = "settings_save_timer",  .enabled = true},
+        {.tag = "settings_update",      .enabled = true},
+        {.tag = "sys_info",             .enabled = true},
+        {.tag = "bridge",               .enabled = false},
+        {.tag = "transparent_tcp",      .enabled = false},
+        {.tag = "modbus_tcp",           .enabled = false},
+        {.tag = "modbus_helpers",       .enabled = false},
+        {.tag = "serial",               .enabled = false},
+        {.tag = "tcp_client",           .enabled = true},
+        {.tag = "tcp_server",           .enabled = true},
+        {.tag = "indication",           .enabled = true},
+        {.tag = "network",              .enabled = true},
+        {.tag = "wifi_apsta",           .enabled = true},
+        {.tag = "mio_control",          .enabled = false}
+    };
+
+    void debug_log_init(void)
+    {
+        for (unsigned i = 0; i < ARRAY_SIZE(debug_log_config); i++) {
+            if (debug_log_config[i].enabled) {
+                esp_log_level_set(debug_log_config[i].tag, ESP_LOG_DEBUG);
+            }
+        }
+    }
+
+    bool debug_log_is_enabled(const char* tag)
+    {
+        if (tag == NULL) {
+            return false;
+        }
+
+        for (unsigned i = 0; i < ARRAY_SIZE(debug_log_config); i++) {
+            if (strcmp(debug_log_config[i].tag, tag) == 0) {
+                return debug_log_config[i].enabled;
+            }
+        }
+
+        return false;
+    }
+
+#else
+
+    void debug_log_init(void)
+    {
+    }
+
+    bool debug_log_is_enabled(const char* tag)
+    {
+        (void)tag;
+        return false;
+    }
+
+#endif

--- a/main/debug_log.c
+++ b/main/debug_log.c
@@ -1,8 +1,11 @@
 #include <stdbool.h>
 #include <string.h>
 #include "esp_log.h"
-#include "debug_log.h"
 #include "array_size.h"
+
+
+#define DEBUG_LOG_ENABLE        0   // Global debug logs enable
+
 
 #if (DEBUG_LOG_ENABLE)
 
@@ -25,8 +28,8 @@
         {.tag = "modbus_tcp",           .enabled = false},
         {.tag = "modbus_helpers",       .enabled = false},
         {.tag = "serial",               .enabled = false},
-        {.tag = "tcp_client",           .enabled = true},
-        {.tag = "tcp_server",           .enabled = true},
+        {.tag = "tcp_client",           .enabled = false},
+        {.tag = "tcp_server",           .enabled = false},
         {.tag = "indication",           .enabled = true},
         {.tag = "network",              .enabled = true},
         {.tag = "wifi_apsta",           .enabled = true},

--- a/main/debug_log.h
+++ b/main/debug_log.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define DEBUG_LOG_ENABLE        1   // Global debug logs enable
+
+void debug_log_init(void);
+bool debug_log_is_enabled(const char* tag);

--- a/main/debug_log.h
+++ b/main/debug_log.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define DEBUG_LOG_ENABLE        1   // Global debug logs enable
+#include <stdbool.h>
 
 void debug_log_init(void);
 bool debug_log_is_enabled(const char* tag);

--- a/main/gpio_expander.c
+++ b/main/gpio_expander.c
@@ -18,6 +18,7 @@ static const i2c_master_bus_config_t bus_config = {
     .sda_io_num = GPIO_EXPANDER_SDA_PIN,
     .scl_io_num = GPIO_EXPANDER_SCL_PIN,
     .clk_source = I2C_CLK_SRC_DEFAULT,
+    .flags.enable_internal_pullup = 1
 };
 
 static esp_io_expander_handle_t gpio_expander = NULL;

--- a/main/gpio_expander.c
+++ b/main/gpio_expander.c
@@ -1,6 +1,7 @@
 #include "esp_io_expander_tca95xx_16bit.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
+#include "debug_log.h"
 
 
 #define GPIO_EXPANDER_I2C_PORT      I2C_NUM_0
@@ -37,9 +38,12 @@ esp_err_t gpio_expander_init(esp_io_expander_handle_t* handle)
         ESP_LOGE(TAG, "Unable to create GPIO expander object");
         return ESP_FAIL;
     }
-    if (esp_io_expander_print_state(gpio_expander) != ESP_OK) {
-        ESP_LOGE(TAG, "Unable to print GPIO expander state");
-        return ESP_FAIL;
+
+    if (debug_log_is_enabled(TAG)) {
+        if (esp_io_expander_print_state(gpio_expander) != ESP_OK) {
+            ESP_LOGE(TAG, "Unable to print GPIO expander state");
+            return ESP_FAIL;
+        }
     }
 
     if (handle) {

--- a/main/indication/indication.c
+++ b/main/indication/indication.c
@@ -10,8 +10,6 @@
 #include "network.h"
 
 
-#define INDICATION_DEBUG_LOG_ENABLE     1           // TODO: Возможно, вынести в настройки
-
 #define INDICATION_TASK_STACK_SIZE      (3 * 1024)
 #define INDICATION_TASK_PRIORITY        1
 
@@ -263,10 +261,6 @@ esp_err_t indication_init(esp_io_expander_handle_t io_expander_handle)
 {
     if (indication_initialized) {
         return ESP_OK;  // Already initialized
-    }
-
-    if (INDICATION_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
     }
 
     if (!io_expander_handle) {

--- a/main/main.c
+++ b/main/main.c
@@ -63,13 +63,12 @@ static const char *TAG = "main";
 #endif
 
 
-// Выводит все настройки в лог.
-// TODO: В релизе удалить
+// Выводит все настройки в лог
 static inline void print_setting_items(void)
 {
     char value[SETTING_ITEM_MAX_STR_LEN] = {0};
 
-    ESP_LOGD(TAG, "=== Current Settings ===");
+    ESP_LOGI(TAG, "=== Current Settings ===");
 
     size_t count = setting_items_get_count();
     for (size_t i = 0; i < count; i++) {
@@ -77,19 +76,19 @@ static inline void print_setting_items(void)
         if (key) {
             // Skip printing any setting that contains 'pass' for security
             if ((key != NULL) && (strstr(key, "pass") != NULL)) {
-                ESP_LOGD(TAG, "%s: [HIDDEN]", key);
+                ESP_LOGI(TAG, "%s: [HIDDEN]", key);
                 continue;
             }
 
             if (setting_items_read(key, value) == ESP_OK) {
-                ESP_LOGD(TAG, "%s: %s", key, value);
+                ESP_LOGI(TAG, "%s: %s", key, value);
             } else {
                 ESP_LOGW(TAG, "%s: [not found]", key);
             }
         }
     }
 
-    ESP_LOGD(TAG, "=== Settings printed (passwords hidden for security) ===");
+    ESP_LOGI(TAG, "=== Settings printed (passwords hidden for security) ===");
 }
 
 
@@ -101,9 +100,7 @@ void app_main(void)
 
     ESP_ERROR_CHECK(nvs_init());
     ESP_ERROR_CHECK(setting_items_init());
-    if (debug_log_is_enabled(TAG)) {
-        print_setting_items();
-    }
+    print_setting_items();
 
     ESP_ERROR_CHECK(network_init());
     ESP_ERROR_CHECK(http_server_init());

--- a/main/main.c
+++ b/main/main.c
@@ -11,6 +11,7 @@
 #include "config_button.h"
 #include "system_voltage.h"
 #include "network.h"
+#include "settings_update.h"
 #include "debug_log.h"
 
 // QEMU build conditional includes
@@ -44,8 +45,6 @@ static const char *TAG = "main";
 #if (!QEMU_BUILD)
     static void factory_reset(void)
     {
-        ESP_LOGI(TAG, "Factory reset initiated!");
-
         ESP_LOGI(TAG, "Resetting all settings to factory defaults...");
         ESP_ERROR_CHECK(setting_items_set_defaults(false));
 
@@ -59,6 +58,7 @@ static const char *TAG = "main";
         ESP_LOGW(TAG, "Factory reset triggered by 5-second config button hold!");
         indication_status_led_blink_n_times(STATUS_LED_FACTORY_RESET_BLINK_PERIOD_MS, STATUS_LED_FACTORY_RESET_BLINK_COUNT);
         factory_reset();
+        settings_update();
     }
 #endif
 

--- a/main/main.c
+++ b/main/main.c
@@ -11,6 +11,7 @@
 #include "config_button.h"
 #include "system_voltage.h"
 #include "network.h"
+#include "debug_log.h"
 
 // QEMU build conditional includes
 #if (QEMU_BUILD)
@@ -68,7 +69,7 @@ static inline void print_setting_items(void)
 {
     char value[SETTING_ITEM_MAX_STR_LEN] = {0};
 
-    ESP_LOGI(TAG, "=== Current Settings ===");
+    ESP_LOGD(TAG, "=== Current Settings ===");
 
     size_t count = setting_items_get_count();
     for (size_t i = 0; i < count; i++) {
@@ -76,31 +77,36 @@ static inline void print_setting_items(void)
         if (key) {
             // Skip printing any setting that contains 'pass' for security
             if ((key != NULL) && (strstr(key, "pass") != NULL)) {
-                ESP_LOGI(TAG, "%s: [HIDDEN]", key);
+                ESP_LOGD(TAG, "%s: [HIDDEN]", key);
                 continue;
             }
 
             if (setting_items_read(key, value) == ESP_OK) {
-                ESP_LOGI(TAG, "%s: %s", key, value);
+                ESP_LOGD(TAG, "%s: %s", key, value);
             } else {
                 ESP_LOGW(TAG, "%s: [not found]", key);
             }
         }
     }
 
-    ESP_LOGI(TAG, "=== Settings printed (passwords hidden for security) ===");
+    ESP_LOGD(TAG, "=== Settings printed (passwords hidden for security) ===");
 }
 
 
 void app_main(void)
 {
+    debug_log_init();
+
     ESP_ERROR_CHECK(sys_info_init());
+
     ESP_ERROR_CHECK(nvs_init());
     ESP_ERROR_CHECK(setting_items_init());
+    if (debug_log_is_enabled(TAG)) {
+        print_setting_items();
+    }
+
     ESP_ERROR_CHECK(network_init());
     ESP_ERROR_CHECK(http_server_init());
-
-    print_setting_items();
 
     #if (!QEMU_BUILD)
         gpio_expander_init(&gpio_expander);

--- a/main/mio_control.c
+++ b/main/mio_control.c
@@ -31,9 +31,9 @@ void mio_control_io_bus_onoff(bool enabled)
 
     if (enabled) {
         esp_io_expander_set_level(io_expander, MIO_RESET_PIN, 1);
-        ESP_LOGI(TAG, "IO bus enabled");
+        ESP_LOGD(TAG, "IO bus enabled");
     } else {
         esp_io_expander_set_level(io_expander, MIO_RESET_PIN, 0);
-        ESP_LOGI(TAG, "IO bus disabled");
+        ESP_LOGD(TAG, "IO bus disabled");
     }
 }

--- a/main/network/network.c
+++ b/main/network/network.c
@@ -9,9 +9,6 @@
 #include "esp_log.h"
 
 
-#define NETWORK_DEBUG_LOG_ENABLE        1       // TODO: Возможно, вынести в настройки
-
-
 typedef struct {
     bool dhcp_client;
     esp_netif_ip_info_t static_ip;
@@ -478,10 +475,6 @@ static esp_err_t init_ethernet(ethernet_settings_t* eth_settings, char* hostname
 
 esp_err_t network_init(void)
 {
-    if (NETWORK_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (esp_event_loop_create_default() != ESP_OK) {
         ESP_LOGE(TAG, "Failed to initialize default event loop");
         return ESP_FAIL;

--- a/main/network/wifi_apsta.c
+++ b/main/network/wifi_apsta.c
@@ -10,8 +10,6 @@
 #include "lwip/ip4_addr.h"
 
 
-#define WIFI_APSTA_DEBUG_LOG_ENABLE         1       // TODO: Возможно, вынести в настройки
-
 #define MAX_STA_CONN                        5
 
 #define WIFI_STA_CONNECT_READY_BIT          BIT0
@@ -401,10 +399,6 @@ void stop_sta_connect_task(void)
 
 esp_err_t wifi_init_apsta(wifi_apsta_config_t* apsta_cfg, char* netif_hostname)
 {
-    if (WIFI_APSTA_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (wifi_ctx.initialized) {
         ESP_LOGW(TAG, "Already initialized");
         return ESP_ERR_NOT_ALLOWED;

--- a/main/network/wifi_apsta.c
+++ b/main/network/wifi_apsta.c
@@ -442,12 +442,13 @@ esp_err_t wifi_init_apsta(wifi_apsta_config_t* apsta_cfg, char* netif_hostname)
     ESP_RETURN_ON_FALSE(configure_ap_sta(apsta_cfg, netif_hostname) == ESP_OK, ESP_FAIL, TAG, "Failed to configure WiFi AP/STA");
     ESP_RETURN_ON_FALSE(esp_wifi_start() == ESP_OK, ESP_FAIL, TAG, "Failed to start WiFi");
 
+    wifi_ctx.config_mode = apsta_cfg->wifi_mode;
+    wifi_ctx.real_mode = real_mode;
+
     if (start_sta_connect_task() != ESP_OK) {
         return ESP_FAIL;
     }
 
-    wifi_ctx.config_mode = apsta_cfg->wifi_mode;
-    wifi_ctx.real_mode = real_mode;
     wifi_ctx.initialized = true;
 
     return ESP_OK;

--- a/main/nv_storage.c
+++ b/main/nv_storage.c
@@ -7,19 +7,12 @@
 #include "nvs_flash.h"
 
 
-#define NV_STORAGE_DEBUG_LOG_ENABLE     0       // TODO: Возможно, вынести в настройки
-
-
 static const char *TAG = "nv_storage";
 static const char *NVS_NAMESPACE = "storage";
 
 
 esp_err_t nvs_init(void)
 {
-    if (NV_STORAGE_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     ESP_LOGD(TAG, "Initializing NVS");
 
     esp_err_t ret = nvs_flash_init();

--- a/main/setting_items.c
+++ b/main/setting_items.c
@@ -55,7 +55,7 @@ static const char *get_dynamic_ap_pass_default(void)
             if (ret >= sizeof(generated_password)) {
                 ESP_LOGW(TAG, "Generated password was truncated");
             }
-            ESP_LOGI(TAG, "Generated AP password from MAC: %02X:%02X:%02X:%02X:%02X:%02X -> %s",
+            ESP_LOGD(TAG, "Generated AP password from MAC: %02X:%02X:%02X:%02X:%02X:%02X -> %s",
                      mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], generated_password);
         } else {
             // Fallback to default if MAC read fails
@@ -84,7 +84,7 @@ static const char *get_dynamic_hostname_default(void)
             if (ret >= sizeof(generated_hostname)) {
                 ESP_LOGW(TAG, "Generated hostname was truncated");
             }
-            ESP_LOGI(TAG, "Generated hostname from MAC: %02X:%02X:%02X:%02X:%02X:%02X -> %s",
+            ESP_LOGD(TAG, "Generated hostname from MAC: %02X:%02X:%02X:%02X:%02X:%02X -> %s",
                      mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], generated_hostname);
         } else {
             // Fallback to base hostname if MAC read fails

--- a/main/setting_items.c
+++ b/main/setting_items.c
@@ -10,9 +10,6 @@
 #include <stdlib.h>
 #include <esp_log.h>
 
-
-#define SETTING_ITEMS_DEBUG_LOG_ENABLE      0           // TODO: Возможно, вынести в настройки
-
 static const char *TAG = "setting_items";
 
 typedef bool (*setting_validator_t)(const char *value);
@@ -211,10 +208,6 @@ esp_err_t setting_items_set_defaults(bool only_uninitialized)
 
 esp_err_t setting_items_init(void)
 {
-    if (SETTING_ITEMS_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     ESP_LOGI(TAG, "Initializing settings with string storage");
     storage_iface = &nvs_storage_iface;
 

--- a/main/settings_save_timer.c
+++ b/main/settings_save_timer.c
@@ -2,8 +2,6 @@
 #include "esp_log.h"
 
 
-#define SETTING_SAVE_TIMER_DEBUG_LOG_ENABLE     1       // TODO: Возможно, вынести в настройки
-
 #define SETTING_SAVE_TIMER_INTERVAL_MS          1000    // Минимальный интервал между сохранением настроек
 #define EVENT_BIT_READY                         BIT0    // Бит (флаг) готовности таймера к следующему сохранению настроек
 
@@ -25,10 +23,6 @@ static void timer_callback(TimerHandle_t pxTimer)
 
 esp_err_t settings_save_timer_auto_init(void)
 {
-    if (SETTING_SAVE_TIMER_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     if (event_group == NULL) {
         event_group = xEventGroupCreate();
         if (event_group == NULL) {

--- a/main/settings_update.c
+++ b/main/settings_update.c
@@ -8,8 +8,6 @@
 #include "update_rs485_mio_gpio_states.h"
 
 
-#define SETTINGS_UPDATE_DEBUG_LOG_ENABLE    1               // TODO: Возможно, вынести в настройки
-
 #define SETTINGS_UPDATE_TASK_STACK_SIZE     (6 * 1024)
 #define SETTINGS_UPDATE_TASK_PRIORITY       5
 
@@ -74,15 +72,6 @@ static void settings_update_task(void *arg)
 
 void settings_update(void)
 {
-    static bool log_initialized = false;
-
-    if (!log_initialized) {
-        if (SETTINGS_UPDATE_DEBUG_LOG_ENABLE) {
-            esp_log_level_set(TAG, ESP_LOG_DEBUG);
-        }
-        log_initialized = true;
-    }
-
     update_rs485_control();
     update_io_bus_control();
 

--- a/main/sys_info.c
+++ b/main/sys_info.c
@@ -6,8 +6,6 @@
 #include "esp_efuse.h"
 
 
-#define SYS_INFO_DEBUG_LOG_ENABLE       1           // TODO: Возможно, вынести в настройки
-
 #define SIGNATURE_EFUSE_BLOCK           EFUSE_BLK3
 #define SIGNATURE_EFUSE_OFFSET          8
 
@@ -87,10 +85,6 @@ static void get_device_signature(char out_buf[DEVICE_SIGNATURE_LEN + 1])
 
 esp_err_t sys_info_init(void)
 {
-    if (SYS_INFO_DEBUG_LOG_ENABLE) {
-        esp_log_level_set(TAG, ESP_LOG_DEBUG);
-    }
-
     sys_info.device_serial_num = generate_serial_from_mac();
 
     GET_APP_DESC_STR_FIELD(fw_version, sys_info.firmware_ver);

--- a/main/update_rs485_mio_gpio_states.c
+++ b/main/update_rs485_mio_gpio_states.c
@@ -12,8 +12,6 @@ static const char *TAG = "update_rs485_mio_gpio_states";
 // обновляет состояние подтяжек, питания и терминаторов RS485 в соответствии с текущими настройками
 void update_rs485_control(void)
 {
-    ESP_LOGI(TAG, "%s", __func__);
-
     bool pullup_1_enabled = setting_items_read_bool(KEY_485_FAIL_SAFE_1);
     bool pullup_2_enabled = setting_items_read_bool(KEY_485_FAIL_SAFE_2);
     bool term_1_enabled = setting_items_read_bool(KEY_485_TERM_1);
@@ -31,8 +29,6 @@ void update_rs485_control(void)
 
 void update_io_bus_control(void)
 {
-    ESP_LOGI(TAG, "%s", __func__);
-
     bool io_bus_enabled = setting_items_read_bool(KEY_IO_BUS_ENABLED);
 
     mio_control_io_bus_onoff(io_bus_enabled);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -37,9 +37,8 @@ CONFIG_LWIP_STATS=y
 #
 # eFuse Bit Manager
 #
-# Only for debug purposes
-# TODO: Delete it in production release
-CONFIG_EFUSE_VIRTUAL=y
+# Only for debug purposes, must be disabled in production!
+# CONFIG_EFUSE_VIRTUAL=y
 
 # Task Watchdog Timer panic on timeout (reset system)
 CONFIG_ESP_TASK_WDT_PANIC=y

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -43,3 +43,8 @@ CONFIG_EFUSE_VIRTUAL=y
 
 # Task Watchdog Timer panic on timeout (reset system)
 CONFIG_ESP_TASK_WDT_PANIC=y
+
+#
+# Compiler options
+#
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/unittests/setting_items/setting_items_test.c
+++ b/unittests/setting_items/setting_items_test.c
@@ -33,8 +33,8 @@ const mock_setting_item_t expected_items[] = {
     {"vout", "true", SETTING_ITEM_TYPE_BOOL},
 
     {"wifi_mode", "ap", SETTING_ITEM_TYPE_STRING},
-    {"ap_auth", "open", SETTING_ITEM_TYPE_STRING},
-    {"sta_auth", "open", SETTING_ITEM_TYPE_STRING},
+    {"ap_auth", "wpa2_psk", SETTING_ITEM_TYPE_STRING},
+    {"sta_auth", "wpa2_psk", SETTING_ITEM_TYPE_STRING},
     {"ap_ssid", "WB-MGE", SETTING_ITEM_TYPE_STRING},
     {"ap_pass", "", SETTING_ITEM_TYPE_STRING},
     {"ap_ip_static", "192.168.5.1", SETTING_ITEM_TYPE_STRING},


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Подготовка к релизу:
- Управление debug-логами вынесено в отдельный модуль, отключены все debug-логи
- Выключены виртуальные eFuse, сигнатура теперь читается из реальных eFuse
- Включен по-умолчанию авто-сгенерированный пароль для WiFi точки доступа
- Включена оптимизация компилятора по размеру бинарника

Попутно:
- Пофикшен warning от i2c_master на pull-up'ы
- Пофикшено применение настроек после сброса по 5-секундному удержанию кнопки
- Пофикшено начальное подключение WiFi STA к точке доступа (обнаружилось после отключения логов)

https://wirenboard.youtrack.cloud/issue/FW-1109/Podgotovka-MGE-k-relizu
___________________________________
**Что поменялось для пользователей:**
Теперь обновлять прошивку через веб-интерфейс можно будет только на устройствах с прошитой сигнатурой.

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
На устройстве на столе, фьюзы - как описано в тикете

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Тестами не покрывал, покрываем в рамках отдельной задачи
