### PR TITLE
add gcovr to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libc6-dev \
     libc6-dev-i386 \
     libc6-dev-x32 \
+    gcovr \
     && apt-get clean
 
 WORKDIR /root/esp/project


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил gcovr в dockerfile, чтобы можно было coverage собирать через докер

___________________________________
**Что поменялось для пользователей:**
Ничего

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
Проверил что теперь make coverage работает в докере

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)

