### PR TITLE
Vin measurement research

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2025-12-22 Maxim Toropov <maxim.toropov@wirenboard.com>
-    * version:  1.0.5-rc1
+    * version:  1.0.5
     * fix:      disable device reboot when power supply voltage is outside the operating range
-    * fix:      disable two-point ADC calibration due to these values are not present in eFuse block 3
+    * fix:      disable two-point ADC calibration due to these values are not present in eFuse block 3 and may conflict with signature
 
 2025-12-15 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-12-16 Maxim Toropov <maxim.toropov@wirenboard.com>
+    * version:  1.0.5-rc1
+    * fix:      disable device reboot when power supply voltage is outside the operating range
+
 2025-12-15 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.4
     * fix:      long packets (>120 bytes) splitting during receive from serial

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2025-12-16 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.5-rc1
     * fix:      disable device reboot when power supply voltage is outside the operating range
+    * fix:      disable two-point ADC calibration due to these values are not present in eFuse block 3
 
 2025-12-15 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2025-12-16 Maxim Toropov <maxim.toropov@wirenboard.com>
+2025-12-22 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.5-rc1
     * fix:      disable device reboot when power supply voltage is outside the operating range
     * fix:      disable two-point ADC calibration due to these values are not present in eFuse block 3

--- a/main/main.c
+++ b/main/main.c
@@ -35,8 +35,6 @@
 
 #define CONFIG_BTN_FACTORY_RESET_HOLD_TIME_MS       5000
 
-#define SYS_VOLTAGE_FAIL_REBOOT_DELAY_MS            3000
-
 
 static const char *TAG = "main";
 
@@ -120,9 +118,7 @@ void app_main(void)
         ESP_ERROR_CHECK(voltage_monitor_init(sys_voltage_event_callback));
         float voltage = voltage_monitor_get_sys_voltage();
         if (!voltage_monitor_sys_voltage_is_ok()) {
-            ESP_LOGE(TAG, "System voltage is out of working range, voltage: %.2f V", voltage);
-            vTaskDelay(pdMS_TO_TICKS(SYS_VOLTAGE_FAIL_REBOOT_DELAY_MS));
-            esp_restart();
+            ESP_LOGW(TAG, "System voltage is out of working range, voltage: %.2f V", voltage);
         } else {
             ESP_LOGI(TAG, "System voltage: %.2f V", voltage);
         }

--- a/main/voltage_monitor/voltage_monitor.c
+++ b/main/voltage_monitor/voltage_monitor.c
@@ -153,6 +153,12 @@ esp_err_t voltage_monitor_init(voltage_monitor_callback_t callback_fn)
 
     vm_ctx.sys_voltage_callback_fn = callback_fn;
 
+    if (!vm_ctx.sys_voltage_is_ok) {
+        if (vm_ctx.sys_voltage_callback_fn != NULL) {
+            vm_ctx.sys_voltage_callback_fn(vm_ctx.sys_voltage, vm_ctx.sys_voltage_is_ok);
+        }
+    }
+
     BaseType_t result = xTaskCreate(voltage_monitor_task, "voltage_monitor_task", VM_TASK_STACK_SIZE, NULL, VM_TASK_PRIORITY, &task_handle);
     if (result != pdPASS) {
         vSemaphoreDelete(vm_ctx_mutex);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -37,6 +37,14 @@ CONFIG_ESP_TASK_WDT_PANIC=y
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 
 #
+# ADC Calibration Configurations
+#
+# Disable ADC two-point calibration because really these calibrations
+# are are not present in the eFuse (first 4 bytes in block 3)
+# and to make it possible to use this space in the future for our purpuses
+CONFIG_ADC_CALI_EFUSE_TP_ENABLE=n
+
+#
 # Enable DEBUG log messages activated by esp_log_level_set()
 #
 # Only for debug purposes, must be disabled in production!


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
По результатам исследования погрешности измерения напряжения Vin:
- Убрана перезагрузка при включении при напряжении питания за рабочим диапазоном
- Обнаружена и отключена two-point калибровка АЦП из-за возможного конфликта с сигнатурой. По факту в наших чипах с завода в eFuse прошита калибровка Vref (блок 0) и НЕ прошиты калибровки two-point (блок 3). Калибровка Vref прошивается начиная с 2018 года.

___________________________________
**Что поменялось для пользователей:**
Устройство не будет постоянно перезапускаться при включении при напряжении питания за рабочим диапазоном

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
На устройстве на столе

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Не покрывал, т.к. модули main и voltage_monitor не покрыты тестами
