### PR TITLE
Bugfix: TWDT timeout during firmware update prepare

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
-2026-01-23 Victor Vedenin <victor.vedenin@wirenboard.com>
+2026-01-26 Victor Vedenin <victor.vedenin@wirenboard.com>, Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.7
     * fix:      IP save in firefox
+    * fix:      TWDT timeout during firmware update via WiFi
 
 2025-12-29 Maxim Toropov <maxim.toropov@wirenboard.com>
     * version:  1.0.6

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -30,6 +30,7 @@ CONFIG_LWIP_STATS=y
 
 # Task Watchdog Timer panic on timeout (reset system)
 CONFIG_ESP_TASK_WDT_PANIC=y
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=8
 
 #
 # Compiler options

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -30,7 +30,9 @@ CONFIG_LWIP_STATS=y
 
 # Task Watchdog Timer panic on timeout (reset system)
 CONFIG_ESP_TASK_WDT_PANIC=y
-CONFIG_ESP_TASK_WDT_TIMEOUT_S=8
+
+# Preparing for a firmware update may take about 5-7 seconds
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=10
 
 #
 # Compiler options


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Увеличен тайм-аут Task Watchdog из-за длительного "подвисания" ESP32 при начале обновления прошивки.
Наиболее часто воспроизводится при обновлении через WiFi, время "подвисания" может достигать 5-7 секунд.

___________________________________
**Что поменялось для пользователей:**
Более стабильная работа обновления прошивки OTA через веб-интерфейс из штатной прошивки

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
На устройстве на столе, обновлял прошивку по Ethernet и WiFi
Добавил в таблицу, что необходимо проверять обновление по Ethernet и WiFi, и несколько раз

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Не покрывал, код не менялся
