### PR TITLE
Macos build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,14 @@ ifeq ($(UNAME_S),Darwin)
     GREP := $(shell which ggrep 2>/dev/null || which grep)
     # Try to find GNU find first, then use system find with compatible syntax
     FIND := $(shell which gfind 2>/dev/null || echo "find")
+    # On macOS idf.py is not in PATH by default; resolve via IDF_PATH set by activate script
+    IDF_PY ?= $(if $(IDF_PATH),$(IDF_PATH)/tools/idf.py,idf.py)
 else
     # Linux and other Unix-like systems
     SED := sed
     GREP := grep
     FIND := find
+    IDF_PY ?= idf.py
 endif
 
 #######################################
@@ -128,13 +131,13 @@ build-frontend:
 
 build-idf-project: keys_header_file
 	@echo 'Building ESP-IDF project'
-	@idf.py $(addprefix -D, $(DEFS)) build
+	@$(IDF_PY) $(addprefix -D, $(DEFS)) build
 	@$(MAKE) prepare_release
 
 build-idf-project-internal: DEFS += INTERNAL_BUILD=1
 build-idf-project-internal:
 	@echo 'Building ESP-IDF project (internal, no keys)'
-	@idf.py $(addprefix -D, $(DEFS)) build
+	@$(IDF_PY) $(addprefix -D, $(DEFS)) build
 	@$(MAKE) prepare_release_internal
 
 prepare_release:
@@ -157,7 +160,7 @@ keys_header_file:
 clean:
 	@echo 'Cleaning project'
 	@rm -rf $(BUILD_DIR)
-	@idf.py fullclean
+	@$(IDF_PY) fullclean
 	@rm -rf $(RELEASE_DIR)
 	@rm -rf $(RELEASE_INTERNAL_DIR)
 	@rm -rf $(COVERAGE_REPORT_DIR)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ cd esp-idf
 source export.sh
 ```
 
+For MacOS:
+
+```bash
+# Install Espressif Installation Manager
+brew install eim
+
+# Install ESP-IDF
+eim install -i v5.4
+
+# Activate the environment
+source ~/.espressif/tools/activate_idf_v5.4.sh
+```
+
 ### 2. Clone the Repository
 
 ```bash

--- a/README.ru.md
+++ b/README.ru.md
@@ -44,6 +44,20 @@ cd esp-idf
 source export.sh
 ```
 
+Для MacOS:
+
+```bash
+# Установка Espressif Installation Manager
+brew install eim
+
+# Установка ESP-IDF
+eim install -i v5.4
+
+# Активация окружения
+source ~/.espressif/tools/activate_idf_v5.4.sh  
+```
+
+
 ### 2. Клонирование репозитория
 
 ```bash


### PR DESCRIPTION
Дописал в ридми о том, как ставить ESP-IDF под макось (кстати для линукса espressif тоже рекомендуют не руками качать esp-idf, а ставить через ESP Installation Manager — https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/linux-setup.html), поправил чуть-чуть мейкфайл — почему-то  не пробрасывался PATH для esp-idf.py (возможно из-за установки через eim и на линуксе тоже так будет, если ставить через него, не проверял). 