### PR TITLE
FW-1318: название устройства на странице логина

### DIFF
--- a/main/frontend/src/common/hostname.ts
+++ b/main/frontend/src/common/hostname.ts
@@ -2,16 +2,18 @@ import { ref } from 'vue';
 import { api } from '@/utils/api';
 
 const hostname = ref<string>('');
+let fetched = false;
 
 export const useHostname = () => {
-  const fetchHostname = async () => {
-    try {
-      const data = await api<{ hostname: string }>('hostname');
-      hostname.value = data.hostname;
-    } catch {
-      // ignore — hostname is optional display info
-    }
-  };
-
-  return { hostname, fetchHostname };
+  if (!fetched) {
+    fetched = true;
+    api<{ hostname: string }>('hostname')
+      .then(data => {
+        hostname.value = data.hostname;
+      })
+      .catch(() => {
+        fetched = false;
+      });
+  }
+  return { hostname };
 };

--- a/main/frontend/src/common/hostname.ts
+++ b/main/frontend/src/common/hostname.ts
@@ -1,0 +1,17 @@
+import { ref } from 'vue';
+import { api } from '@/utils/api';
+
+const hostname = ref<string>('');
+
+export const useHostname = () => {
+  const fetchHostname = async () => {
+    try {
+      const data = await api<{ hostname: string }>('hostname');
+      hostname.value = data.hostname;
+    } catch {
+      // ignore — hostname is optional display info
+    }
+  };
+
+  return { hostname, fetchHostname };
+};

--- a/main/frontend/src/common/hostname.ts
+++ b/main/frontend/src/common/hostname.ts
@@ -4,6 +4,10 @@ import { api } from '@/utils/api';
 const hostname = ref<string>('');
 let fetched = false;
 
+export const setHostname = (value: string) => {
+  hostname.value = value;
+};
+
 export const useHostname = () => {
   if (!fetched) {
     fetched = true;

--- a/main/frontend/src/common/settings.ts
+++ b/main/frontend/src/common/settings.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { useAlerts } from '@/common/alert';
 import type { DeepPartial, Settings, UpdateSettingsResponse } from '@/common/types';
 import { api } from '@/utils/api';
+import { setHostname } from '@/common/hostname';
 
 const isDeepEqual = (a: any, b: any): boolean => {
   if (a === b) return true;
@@ -31,6 +32,9 @@ export const useSettings = () => {
   const refresh = async () => {
     data.value = await api<Settings>('settings');
     initData.value = JSON.parse(JSON.stringify(data.value));
+    if (data.value?.hostname) {
+      setHostname(data.value.hostname);
+    }
   };
 
   const isChanged = (fields: string[]) => {

--- a/main/frontend/src/components/Sidebar.vue
+++ b/main/frontend/src/components/Sidebar.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import Logo from '@/assets/logo.svg?component';
 import LogoutIcon from '@/assets/logout.svg?component';
 import MenuIcon from '@/assets/menu.svg?component';
+import { useHostname } from '@/common/hostname';
 
 const { t } = useI18n();
 const route = useRoute();
 const isShowMenu = ref(false);
 const router = useRouter();
+const { hostname, fetchHostname } = useHostname();
+onMounted(() => fetchHostname());
 
 watch(
   () => route.fullPath,
@@ -23,6 +26,7 @@ watch(
   <aside class="sidebar">
     <RouterLink to="/" class="sidebar-logo">
       <Logo alt="Wiren Board" />
+      <div v-if="hostname" class="sidebar-hostname">{{ hostname }}</div>
     </RouterLink>
 
     <MenuIcon class="sidebar-burger" @click="isShowMenu = !isShowMenu" />
@@ -142,6 +146,14 @@ watch(
   width: 20px;
   height: 20px;
   margin-right: 6px;
+}
+
+.sidebar-hostname {
+  font-size: 11px;
+  color: var(--text-color-secondary, #888);
+  text-align: center;
+  margin-top: 4px;
+  word-break: break-all;
 }
 </style>
 

--- a/main/frontend/src/components/Sidebar.vue
+++ b/main/frontend/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import Logo from '@/assets/logo.svg?component';
@@ -11,8 +11,7 @@ const { t } = useI18n();
 const route = useRoute();
 const isShowMenu = ref(false);
 const router = useRouter();
-const { hostname, fetchHostname } = useHostname();
-onMounted(() => fetchHostname());
+const { hostname } = useHostname();
 
 watch(
   () => route.fullPath,

--- a/main/frontend/src/views/Login.vue
+++ b/main/frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import Logo from '@/assets/logo.svg?component';
@@ -9,6 +9,7 @@ import { documentation } from '@/common/links';
 import type { Auth } from '@/common/types';
 import AlertsWrapper from '@/components/AlertsWrapper.vue';
 import { api } from '@/utils/api';
+import { useHostname } from '@/common/hostname';
 
 const { t, locale } = useI18n();
 const router = useRouter();
@@ -16,6 +17,8 @@ const route = useRoute();
 const { showAlert } = useAlerts();
 const data = reactive({ login: '', pass: '' });
 const isLoading = ref(false);
+const { hostname, fetchHostname } = useHostname();
+onMounted(() => fetchHostname());
 
 const login = async () => {
   isLoading.value = true;
@@ -35,6 +38,7 @@ const login = async () => {
 <template>
   <section class="login">
     <Logo alt="Wiren Board" />
+    <div v-if="hostname" class="login-hostname">{{ hostname }}</div>
 
     <div class="login-title">{{ t('title') }}</div>
 
@@ -147,6 +151,12 @@ const login = async () => {
   background-size: 14px;
   height: 14px;
   width: 14px;
+}
+
+.login-hostname {
+  font-size: 13px;
+  color: var(--text-color-secondary, #888);
+  margin-top: 6px;
 }
 </style>
 

--- a/main/frontend/src/views/Login.vue
+++ b/main/frontend/src/views/Login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue';
+import { reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import Logo from '@/assets/logo.svg?component';
@@ -17,8 +17,7 @@ const route = useRoute();
 const { showAlert } = useAlerts();
 const data = reactive({ login: '', pass: '' });
 const isLoading = ref(false);
-const { hostname, fetchHostname } = useHostname();
-onMounted(() => fetchHostname());
+const { hostname } = useHostname();
 
 const login = async () => {
   isLoading.value = true;

--- a/main/http_server.c
+++ b/main/http_server.c
@@ -191,6 +191,12 @@ static const httpd_uri_t wb_status_get = {
     .handler = wb_status_get_handler,
     .user_ctx = NULL,
 };
+static const httpd_uri_t hostname_get = {
+    .uri = "/hostname",
+    .method = HTTP_GET,
+    .handler = hostname_get_handler,
+    .user_ctx = NULL,
+};
 
 
 static uint16_t get_web_port_setting(void)
@@ -245,6 +251,7 @@ esp_err_t http_server_init(void)
         httpd_register_uri_handler(http_server, &wb_test_get);
         httpd_register_uri_handler(http_server, &wb_test_post);
         httpd_register_uri_handler(http_server, &wb_status_get);
+        httpd_register_uri_handler(http_server, &hostname_get);
     }
 
     if (http_server == NULL) {

--- a/main/info_handlers.c
+++ b/main/info_handlers.c
@@ -1,6 +1,7 @@
 #include "info_handlers.h"
 #include "json_utils.h"
 #include "auth.h"
+#include "setting_items.h"
 #include "bridge.h"
 #include "wifi_apsta.h"
 #include "config.h"
@@ -397,5 +398,22 @@ esp_err_t wb_status_get_handler(httpd_req_t *req)
     }
 
     json_utils_send_response(req, NULL, wb_status_json);
+    return ESP_OK;
+}
+
+esp_err_t hostname_get_handler(httpd_req_t *req)
+{
+    ESP_LOGI(TAG, "Hostname GET request");
+
+    char hostname[SETTING_ITEM_MAX_STR_LEN] = { 0 };
+    setting_items_read(KEY_HOSTNAME, hostname);
+
+    cJSON *response_json = cJSON_CreateObject();
+    if (response_json == NULL) {
+        json_utils_send_error(req, "Failed to create response");
+        return ESP_OK;
+    }
+    cJSON_AddStringToObject(response_json, "hostname", hostname);
+    json_utils_send_response(req, NULL, response_json);
     return ESP_OK;
 }

--- a/main/info_handlers.h
+++ b/main/info_handlers.h
@@ -13,3 +13,6 @@ esp_err_t ap_clients_get_handler(httpd_req_t *req);
 
 // HTTP handler for WB status GET endpoint
 esp_err_t wb_status_get_handler(httpd_req_t *req);
+
+// HTTP handler for hostname GET endpoint (public, no auth)
+esp_err_t hostname_get_handler(httpd_req_t *req);

--- a/unittests/http_server/http_server_test.c
+++ b/unittests/http_server/http_server_test.c
@@ -283,7 +283,8 @@ void test_http_server_uri_handlers_registration(void)
         {"/uptime",            HTTP_GET},
         {"/wb_test",           HTTP_GET},
         {"/wb_test",           HTTP_POST},
-        {"/wb_status",         HTTP_GET}
+        {"/wb_status",         HTTP_GET},
+        {"/hostname",          HTTP_GET}
     };
 
     size_t expected_count = ARRAY_SIZE(expected_uri_registry);
@@ -606,6 +607,10 @@ void test_http_request_external_handlers(void)
     mock_simulate_http_request(HTTP_GET, "/wb_status");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_wb_status_get_handler_called,
                                  "wb_status_get_handler should be called for GET /wb_status");
+
+    mock_simulate_http_request(HTTP_GET, "/hostname");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, mock_hostname_get_handler_called,
+                                 "hostname_get_handler should be called for GET /hostname");
 
     // Test WB Test handlers
     LOG_INFO("Testing WB Test handlers...");

--- a/unittests/http_server/mocks/esp_http_server.c
+++ b/unittests/http_server/mocks/esp_http_server.c
@@ -33,6 +33,7 @@ int mock_uptime_get_handler_called = 0;
 int mock_wb_test_get_handler_called = 0;
 int mock_wb_test_post_handler_called = 0;
 int mock_wb_status_get_handler_called = 0;
+int mock_hostname_get_handler_called = 0;
 
 int mock_httpd_resp_set_type_call_count = 0;
 int mock_httpd_resp_set_hdr_call_count = 0;
@@ -101,6 +102,7 @@ void mock_handlers_reset(void)
     mock_wb_test_get_handler_called = 0;
     mock_wb_test_post_handler_called = 0;
     mock_wb_status_get_handler_called = 0;
+    mock_hostname_get_handler_called = 0;
 }
 
 esp_err_t httpd_start(httpd_handle_t *handle, const httpd_config_t *config)

--- a/unittests/http_server/mocks/esp_http_server.h
+++ b/unittests/http_server/mocks/esp_http_server.h
@@ -137,6 +137,7 @@ extern int mock_uptime_get_handler_called;
 extern int mock_wb_test_get_handler_called;
 extern int mock_wb_test_post_handler_called;
 extern int mock_wb_status_get_handler_called;
+extern int mock_hostname_get_handler_called;
 
 extern int mock_httpd_resp_set_type_call_count;
 extern int mock_httpd_resp_set_hdr_call_count;

--- a/unittests/http_server/mocks/info_handlers.c
+++ b/unittests/http_server/mocks/info_handlers.c
@@ -23,3 +23,9 @@ esp_err_t wb_status_get_handler(httpd_req_t *req)
     mock_wb_status_get_handler_called = 1;
     return ESP_OK;
 }
+
+esp_err_t hostname_get_handler(httpd_req_t *req)
+{
+    mock_hostname_get_handler_called = 1;
+    return ESP_OK;
+}


### PR DESCRIPTION

___________________________________
**Что происходит; кому и зачем нужно:**
Пользователи хотят название на странице логина: https://support.wirenboard.com/t/ekran-logina-mgev3/35863

___________________________________
**Что поменялось для пользователей:**
<img width="450" height="209" alt="image" src="https://github.com/user-attachments/assets/d83cc647-2f79-43cb-bd9f-85b68a87167f" />
<img width="525" height="218" alt="image" src="https://github.com/user-attachments/assets/ebd27b3e-b3aa-43d8-bf53-fe57112b088f" />
Теперь хостнейм показывается на экране логина и под логотипом в интерфейсе.

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
Не требует проверки, изменение во фронте

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
Покрыто
