### PR TITLE
Feature/vvzvlad fix macos update bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2026-05-18 Vlad Zaytsev <vlad.zaitsev@wirenboard.com>
     * version:  1.2.0
+
+2026-04-29 Vlad Zaytsev <vlad.zaitsev@wirenboard.com>
+    * version:  1.1.3
+    * fix:      OTA update returning 400 on macOS due to application/macbinary Content-Type
+
+2026-04-29 Vlad Zaytsev <vlad.zaitsev@wirenboard.com>
+    * version:  1.1.2
     * added:    redesigned UI with new design system and component updates
     * change:    split settings into separate Network and Serial Ports pages, add TCP gateway page
     * added:    latest firmware version display with download link

--- a/main/ota_handler.c
+++ b/main/ota_handler.c
@@ -65,13 +65,20 @@ static esp_err_t ota_validate_fw_desc(wb_app_desc_t* ota_fw_desc)
 }
 
 
+static bool ota_is_valid_content_type(const char *content_type)
+{
+    return (strstr(content_type, "application/octet-stream") != NULL) ||
+           (strstr(content_type, "application/macbinary") != NULL);
+}
+
+
 static esp_err_t ota_validate_content_type(httpd_req_t *req)
 {
     char content_type[64];
     if (httpd_req_get_hdr_value_str(req, "Content-Type", content_type, sizeof(content_type)) == ESP_OK) {
-        if (strstr(content_type, "application/octet-stream") == NULL) {
+        if (!ota_is_valid_content_type(content_type)) {
             ESP_LOGW(TAG, "Invalid content type for OTA update: %s", content_type);
-            return json_utils_send_error(req, "Invalid content type. Expected: application/octet-stream");
+            return ESP_FAIL;
         }
     } else {
         ESP_LOGW(TAG, "No Content-Type header found, proceeding anyway");


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
на макоси ложно появлялось сообщение об ошибке обновления, т.к. браузеры отдавали .bin с Content-Type=application/macbinary. обновление все равно работало, но неаккуратно

___________________________________
**Что поменялось для пользователей:**
обновление проходит без ошибок

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)


___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)

