### PR TITLE
build(ota): add OTA flash make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,34 @@ clean:
 		fi; \
 	done
 
-.PHONY: all unittests build-frontend build-idf-project prepare_release clean
+#######################################
+# OTA flash
+#######################################
+
+OTA_HOST ?= 192.168.1.1
+OTA_USER ?= admin
+OTA_PASS ?= admin
+OTA_COOKIE_FILE := /tmp/mge_ota_cookie.txt
+
+ota-flash:
+	@echo "Flashing $(RELEASE_DIR)/$(RELEASE_FILE_NAME) to http://$(OTA_HOST)/ ..."
+	@AUTH_RESULT=$$(curl -s -c $(OTA_COOKIE_FILE) -X POST http://$(OTA_HOST)/auth \
+		-H "Content-Type: application/json" \
+		-d '{"login":"$(OTA_USER)","pass":"$(OTA_PASS)"}'); \
+	echo "$$AUTH_RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); exit(0 if d.get('auth') else 1)" \
+		|| (echo "ERROR: Authentication failed: $$AUTH_RESULT"; exit 1)
+	@echo "Authenticated, uploading firmware..."
+	@curl --progress-bar -b $(OTA_COOKIE_FILE) \
+		-X POST http://$(OTA_HOST)/update \
+		-H "Content-Type: application/octet-stream" \
+		--data-binary @$(RELEASE_DIR)/$(RELEASE_FILE_NAME) \
+		--max-time 60 \
+		| python3 -c "import sys,json; d=json.load(sys.stdin); exit(0) if d.get('success') else (print('ERROR:', d), exit(1))" \
+		|| (echo "ERROR: Firmware upload failed"; exit 1)
+	@rm -f $(OTA_COOKIE_FILE)
+	@echo "OTA flash complete, device is rebooting"
+
+.PHONY: all unittests build-frontend build-idf-project prepare_release clean ota-flash
 
 # Include coverage definitions and targets
 -include unittests/build_common_coverage.mk


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сделал цель в мейкфайле для прошивки устройств из консоли сразу после сборки: make build-frontend build-idf-project ota-flash OTA_HOST=10.31.41.195

___________________________________
**Что поменялось для пользователей:**
для обычного использования ничего

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
не требуется

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
не требуется