### PR TITLE
Автоопределение языка веб-интерфейса и читаемый список языков на логине (SOFT-7355, SOFT-7354)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-08-25 Vlad Zaytsev <vlad.zaitsev@wirenboard.com>
+    * version:  1.3.1
+    * fix:      open the web interface in the browser's language — a region-qualified tag such as ru-RU, de-AT, it-CH or kk-KZ used to miss the match and fall back to English
+    * fix:      keep the login-page language dropdown readable in Chromium-based browsers (Edge, Chrome), where every entry except the highlighted one was drawn white on white
+    * fix:      load the web interface when the browser denies site storage — reading the saved language used to throw and abort the whole interface, not merely lose the choice
+
 2026-06-25 Vlad Zaytsev <vlad.zaitsev@wirenboard.com>
     * version:  1.3.0
     * added:    Modbus sniffer — live RS-485 capture over WebSocket with slave/function-code facet filters, CSV export, error stats, and Fast Modbus decode

--- a/main/frontend/src/i18n/index.ts
+++ b/main/frontend/src/i18n/index.ts
@@ -1,10 +1,9 @@
 import { createI18n } from 'vue-i18n';
 import { messages } from './messages';
+import { DEFAULT_LANGUAGE, preferredTags, resolveLocale, type Locale } from './resolveLocale';
 import { slavicPluralization } from './slavicPluralization';
 
-export type Locale = 'en' | 'ru' | 'kk' | 'it' | 'de';
-
-const SUPPORTED_LANGUAGES: Locale[] = ['en', 'ru', 'kk', 'it', 'de'];
+export type { Locale } from './resolveLocale';
 
 export const languages: Record<Locale, string> = {
   en: 'English',
@@ -14,9 +13,18 @@ export const languages: Record<Locale, string> = {
   de: 'Deutsch',
 };
 
-const DEFAULT_LANGUAGE = 'en';
+// Reading localStorage throws, rather than returning null, where a site is denied
+// storage. This runs at module scope, so an unguarded throw would abort the import of
+// @/i18n and take the whole UI down — degrade to "no stored choice" instead.
+const storedLanguage = (): string | null => {
+  try {
+    return localStorage.getItem('lang');
+  } catch {
+    return null;
+  }
+};
 
-const locale = localStorage.getItem('lang') ?? ( SUPPORTED_LANGUAGES.includes(navigator.language as Locale) ? navigator.language : DEFAULT_LANGUAGE);
+const locale = resolveLocale(storedLanguage(), preferredTags(navigator.languages, navigator.language));
 document.documentElement.lang = locale;
 
 export const i18n = createI18n({
@@ -33,6 +41,11 @@ export const i18n = createI18n({
 
 export const changeLang = (lang: Locale) => {
   i18n.global.locale.value = lang;
-  localStorage.setItem('lang', lang);
+  try {
+    localStorage.setItem('lang', lang);
+  } catch {
+    // Storage is denied: the switch still applies for this page load, it just will not
+    // survive a reload.
+  }
   document.documentElement.lang = lang;
 };

--- a/main/frontend/src/i18n/index.ts
+++ b/main/frontend/src/i18n/index.ts
@@ -13,9 +13,8 @@ export const languages: Record<Locale, string> = {
   de: 'Deutsch',
 };
 
-// Reading localStorage throws, rather than returning null, where a site is denied
-// storage. This runs at module scope, so an unguarded throw would abort the import of
-// @/i18n and take the whole UI down — degrade to "no stored choice" instead.
+// Where a site is denied storage the localStorage access itself throws, and this is called
+// while the module loads — an unguarded throw would take the whole UI down with it.
 const storedLanguage = (): string | null => {
   try {
     return localStorage.getItem('lang');
@@ -44,8 +43,7 @@ export const changeLang = (lang: Locale) => {
   try {
     localStorage.setItem('lang', lang);
   } catch {
-    // Storage is denied: the switch still applies for this page load, it just will not
-    // survive a reload.
+    // Storage denied: the switch applies now, it just will not survive a reload.
   }
   document.documentElement.lang = lang;
 };

--- a/main/frontend/src/i18n/resolveLocale.test.ts
+++ b/main/frontend/src/i18n/resolveLocale.test.ts
@@ -1,17 +1,3 @@
-/**
- * Unit tests for resolveLocale() and preferredTags() from src/i18n/resolveLocale.ts
- * (SOFT-7355).
- *
- * The UI used to compare the raw navigator language against the list of shipped
- * locales, so every region-qualified tag a browser reports ('ru-RU', 'de-AT', ...)
- * missed and the interface opened in English on a Russian browser. These tests pin
- * the normalisation (region suffixes, separators, case), the precedence between an
- * explicit stored choice and the browser list, and the fallback to 'en'.
- *
- * resolveLocale.ts deliberately touches no DOM global, so it runs under the 'unit'
- * vitest project (environment: 'node') where localStorage/navigator do not exist.
- */
-
 import { describe, expect, it } from 'vitest';
 import { preferredTags, resolveLocale } from '@/i18n/resolveLocale';
 
@@ -84,11 +70,9 @@ describe('resolveLocale', () => {
   });
 
   it('matches a language code exactly rather than by prefix', () => {
-    // Guards against replacing the primary-subtag lookup in normalizeTag() with
-    // SUPPORTED_LANGUAGES.find((l) => normalized.startsWith(l)): that reads naturally and
-    // keeps every other test green, but hands Russian to a 'rue' speaker, Italian to an
-    // 'ita-IT' one, and lets an unsupported stored 'english' outrank the real browser
-    // preference. Both lookups compare whole codes, not prefixes.
+    // Guards against rewriting normalizeTag()'s lookups as a startsWith() scan: that
+    // keeps every other test green, but hands Russian to a 'rue' speaker and lets a
+    // stored 'english' outrank the browser.
     expect(resolveLocale(null, ['rue'])).toBe('en');
     expect(resolveLocale(null, ['ita-IT'])).toBe('en');
     expect(resolveLocale('english', ['ru-RU'])).toBe('ru');

--- a/main/frontend/src/i18n/resolveLocale.test.ts
+++ b/main/frontend/src/i18n/resolveLocale.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for resolveLocale() and preferredTags() from src/i18n/resolveLocale.ts
+ * (SOFT-7355).
+ *
+ * The UI used to compare the raw navigator language against the list of shipped
+ * locales, so every region-qualified tag a browser reports ('ru-RU', 'de-AT', ...)
+ * missed and the interface opened in English on a Russian browser. These tests pin
+ * the normalisation (region suffixes, separators, case), the precedence between an
+ * explicit stored choice and the browser list, and the fallback to 'en'.
+ *
+ * resolveLocale.ts deliberately touches no DOM global, so it runs under the 'unit'
+ * vitest project (environment: 'node') where localStorage/navigator do not exist.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { preferredTags, resolveLocale } from '@/i18n/resolveLocale';
+
+describe('resolveLocale', () => {
+  it('resolves a region-qualified ru-RU to ru (the SOFT-7355 bug)', () => {
+    expect(resolveLocale(null, ['ru-RU'])).toBe('ru');
+  });
+
+  it('still resolves a bare ru to ru', () => {
+    expect(resolveLocale(null, ['ru'])).toBe('ru');
+  });
+
+  it('matches tags case-insensitively', () => {
+    expect(resolveLocale(null, ['RU-ru'])).toBe('ru');
+    expect(resolveLocale(null, ['DE'])).toBe('de');
+  });
+
+  it('resolves the other region-qualified languages we ship', () => {
+    expect(resolveLocale(null, ['de-AT'])).toBe('de');
+    expect(resolveLocale(null, ['it-CH'])).toBe('it');
+    expect(resolveLocale(null, ['kk-KZ'])).toBe('kk');
+  });
+
+  it('accepts an underscore as the subtag separator', () => {
+    expect(resolveLocale(null, ['ru_RU'])).toBe('ru');
+  });
+
+  it('falls back to the default for a multi-subtag tag we do not ship', () => {
+    expect(resolveLocale(null, ['zh-Hant-TW'])).toBe('en');
+  });
+
+  it('falls back to the default for an unsupported language', () => {
+    expect(resolveLocale(null, ['fr-FR'])).toBe('en');
+  });
+
+  it('honours the browser preference order rather than the supported-list order', () => {
+    expect(resolveLocale(null, ['fr-FR', 'ru-RU', 'en-US'])).toBe('ru');
+  });
+
+  it('lets an explicit stored choice win over the browser preference', () => {
+    expect(resolveLocale('en', ['ru-RU'])).toBe('en');
+  });
+
+  it('normalises a region-qualified stored value written by an older build', () => {
+    expect(resolveLocale('ru-RU', [])).toBe('ru');
+  });
+
+  it('ignores an unsupported stored value and keeps detecting from the browser', () => {
+    expect(resolveLocale('fr', ['ru-RU'])).toBe('ru');
+  });
+
+  it('returns the default when nothing is stored and nothing is preferred', () => {
+    expect(resolveLocale(null, [])).toBe('en');
+    expect(resolveLocale(undefined, [])).toBe('en');
+  });
+
+  it('skips blank entries instead of letting them match', () => {
+    expect(resolveLocale('', ['   ', 'ru-RU'])).toBe('ru');
+    expect(resolveLocale(null, ['', '  '])).toBe('en');
+  });
+
+  it('trims surrounding whitespace off a tag before matching it', () => {
+    expect(resolveLocale(' ru ', [])).toBe('ru');
+    expect(resolveLocale(null, ['\tru-RU '])).toBe('ru');
+  });
+
+  it('rejects a tag that is only a subtag separator', () => {
+    expect(resolveLocale(null, ['-', '_', 'ru'])).toBe('ru');
+    expect(resolveLocale('-', ['ru-RU'])).toBe('ru');
+  });
+
+  it('matches a language code exactly rather than by prefix', () => {
+    // Guards against replacing the primary-subtag lookup in normalizeTag() with
+    // SUPPORTED_LANGUAGES.find((l) => normalized.startsWith(l)): that reads naturally and
+    // keeps every other test green, but hands Russian to a 'rue' speaker, Italian to an
+    // 'ita-IT' one, and lets an unsupported stored 'english' outrank the real browser
+    // preference. Both lookups compare whole codes, not prefixes.
+    expect(resolveLocale(null, ['rue'])).toBe('en');
+    expect(resolveLocale(null, ['ita-IT'])).toBe('en');
+    expect(resolveLocale('english', ['ru-RU'])).toBe('ru');
+  });
+});
+
+describe('preferredTags', () => {
+  it('returns the browser preference list in order and unchanged', () => {
+    expect(preferredTags(['ru-RU', 'en-US'], 'ru-RU')).toEqual(['ru-RU', 'en-US']);
+  });
+
+  it('returns a copy rather than the live navigator.languages array', () => {
+    const languages = ['ru-RU', 'en-US'];
+    const tags = preferredTags(languages, 'ru-RU');
+    tags.push('de-AT');
+    expect(languages).toEqual(['ru-RU', 'en-US']);
+  });
+
+  it('falls back to the single language when the list is empty', () => {
+    expect(preferredTags([], 'ru-RU')).toEqual(['ru-RU']);
+  });
+
+  it('falls back to the single language when the list is absent', () => {
+    expect(preferredTags(undefined, 'de-AT')).toEqual(['de-AT']);
+  });
+
+  it('falls back instead of throwing when the list is not an array', () => {
+    expect(preferredTags('ru-RU' as unknown as readonly string[], 'ru-RU')).toEqual(['ru-RU']);
+  });
+
+  it('yields an empty list when the browser exposes nothing usable', () => {
+    expect(preferredTags(undefined, undefined)).toEqual([]);
+    expect(preferredTags(undefined, '')).toEqual([]);
+  });
+
+  it('feeds resolveLocale so a Russian browser opens the UI in Russian (SOFT-7355)', () => {
+    expect(resolveLocale(null, preferredTags(['ru-RU', 'en-US'], 'ru-RU'))).toBe('ru');
+  });
+});

--- a/main/frontend/src/i18n/resolveLocale.ts
+++ b/main/frontend/src/i18n/resolveLocale.ts
@@ -1,12 +1,4 @@
-/**
- * Locale resolution, kept free of DOM access so it can be unit tested.
- *
- * The UI ships messages per primary language subtag ('ru', 'de', ...), while both the
- * browser and a stored preference hand us full BCP 47 tags with a region ('ru-RU',
- * 'de-AT'). Matching those tags verbatim against the supported list is what made a
- * Russian browser open the UI in English (SOFT-7355), so every tag goes through
- * normalisation first.
- */
+// Locale resolution, kept free of DOM access so it can be unit tested.
 
 export type Locale = 'en' | 'ru' | 'kk' | 'it' | 'de';
 
@@ -16,11 +8,8 @@ export const DEFAULT_LANGUAGE: Locale = 'en';
 
 const isSupported = (tag: string): tag is Locale => (SUPPORTED_LANGUAGES as readonly string[]).includes(tag);
 
-/**
- * Reduce one language tag to a supported locale, or null when we ship nothing for it.
- * Falls back to the primary subtag — everything before the first '-' or '_' — so both
- * 'ru-RU' and a hand-written 'ru_RU' resolve to 'ru'.
- */
+// Browsers report region-qualified tags ('ru-RU', 'de-AT'), while messages ship per
+// primary subtag — hence the fallback. Both lookups compare whole codes, never prefixes.
 const normalizeTag = (tag: string | null | undefined): Locale | null => {
   const normalized = (tag ?? '').trim().toLowerCase();
   if (!normalized) {
@@ -33,12 +22,6 @@ const normalizeTag = (tag: string | null | undefined): Locale | null => {
   return isSupported(primary) ? primary : null;
 };
 
-/**
- * Order the browser's language tags by preference. `navigator.languages` is the full
- * ordered list; `navigator.language` is only its top entry and the sole thing older
- * engines expose, so it stands in when the list is missing. Anything unusable degrades
- * to an empty list rather than throwing — this runs while the module is still loading.
- */
 export const preferredTags = (languages: readonly string[] | undefined, language: string | undefined): string[] => {
   if (Array.isArray(languages) && languages.length > 0) {
     return [...languages];
@@ -46,14 +29,6 @@ export const preferredTags = (languages: readonly string[] | undefined, language
   return language ? [language] : [];
 };
 
-/**
- * Pick the locale to start the UI in.
- *
- * `stored` is the explicit choice made through the language switcher and wins over the
- * browser — but only when we actually ship it, so a stale or hand-edited value cannot
- * pin the UI to a locale with no messages. Otherwise the browser preference list is
- * walked in order, and the first supported entry wins.
- */
 export const resolveLocale = (stored: string | null | undefined, preferred: readonly string[]): Locale => {
   const explicit = normalizeTag(stored);
   if (explicit) {

--- a/main/frontend/src/i18n/resolveLocale.ts
+++ b/main/frontend/src/i18n/resolveLocale.ts
@@ -1,0 +1,71 @@
+/**
+ * Locale resolution, kept free of DOM access so it can be unit tested.
+ *
+ * The UI ships messages per primary language subtag ('ru', 'de', ...), while both the
+ * browser and a stored preference hand us full BCP 47 tags with a region ('ru-RU',
+ * 'de-AT'). Matching those tags verbatim against the supported list is what made a
+ * Russian browser open the UI in English (SOFT-7355), so every tag goes through
+ * normalisation first.
+ */
+
+export type Locale = 'en' | 'ru' | 'kk' | 'it' | 'de';
+
+export const SUPPORTED_LANGUAGES: readonly Locale[] = ['en', 'ru', 'kk', 'it', 'de'];
+
+export const DEFAULT_LANGUAGE: Locale = 'en';
+
+const isSupported = (tag: string): tag is Locale => (SUPPORTED_LANGUAGES as readonly string[]).includes(tag);
+
+/**
+ * Reduce one language tag to a supported locale, or null when we ship nothing for it.
+ * Falls back to the primary subtag — everything before the first '-' or '_' — so both
+ * 'ru-RU' and a hand-written 'ru_RU' resolve to 'ru'.
+ */
+const normalizeTag = (tag: string | null | undefined): Locale | null => {
+  const normalized = (tag ?? '').trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (isSupported(normalized)) {
+    return normalized;
+  }
+  const primary = normalized.split(/[-_]/)[0];
+  return isSupported(primary) ? primary : null;
+};
+
+/**
+ * Order the browser's language tags by preference. `navigator.languages` is the full
+ * ordered list; `navigator.language` is only its top entry and the sole thing older
+ * engines expose, so it stands in when the list is missing. Anything unusable degrades
+ * to an empty list rather than throwing — this runs while the module is still loading.
+ */
+export const preferredTags = (languages: readonly string[] | undefined, language: string | undefined): string[] => {
+  if (Array.isArray(languages) && languages.length > 0) {
+    return [...languages];
+  }
+  return language ? [language] : [];
+};
+
+/**
+ * Pick the locale to start the UI in.
+ *
+ * `stored` is the explicit choice made through the language switcher and wins over the
+ * browser — but only when we actually ship it, so a stale or hand-edited value cannot
+ * pin the UI to a locale with no messages. Otherwise the browser preference list is
+ * walked in order, and the first supported entry wins.
+ */
+export const resolveLocale = (stored: string | null | undefined, preferred: readonly string[]): Locale => {
+  const explicit = normalizeTag(stored);
+  if (explicit) {
+    return explicit;
+  }
+
+  for (const tag of preferred) {
+    const detected = normalizeTag(tag);
+    if (detected) {
+      return detected;
+    }
+  }
+
+  return DEFAULT_LANGUAGE;
+};

--- a/main/frontend/src/views/Login.vue
+++ b/main/frontend/src/views/Login.vue
@@ -299,6 +299,17 @@ const login = async () => {
   color: #fff;
 }
 
+/* The dropdown list is painted by the browser, and Chromium lets an <option> inherit
+   `color` from its <select> — including the :hover colour, which is live the whole time
+   the list is open, because the pointer sits on the control. That painted every entry
+   white on the light native listbox and left only the highlighted row readable
+   (SOFT-7354). Pin both colours on the options so nothing is inherited: background-color
+   and color are among the few properties Chromium honours on an <option>. */
+.login-lang option {
+  background-color: var(--bg-surface);
+  color: var(--text-color);
+}
+
 .login-colophon {
   font-size: 11.8px; /* +0.8px for Roboto */
   color: var(--text-on-dark-dim);

--- a/main/frontend/src/views/Login.vue
+++ b/main/frontend/src/views/Login.vue
@@ -299,12 +299,8 @@ const login = async () => {
   color: #fff;
 }
 
-/* The dropdown list is painted by the browser, and Chromium lets an <option> inherit
-   `color` from its <select> — including the :hover colour, which is live the whole time
-   the list is open, because the pointer sits on the control. That painted every entry
-   white on the light native listbox and left only the highlighted row readable
-   (SOFT-7354). Pin both colours on the options so nothing is inherited: background-color
-   and color are among the few properties Chromium honours on an <option>. */
+/* Chromium lets an <option> inherit `color` from its <select>, and :hover stays live
+   while the popup is open — pin both colours or the list goes white on white (SOFT-7354). */
 .login-lang option {
   background-color: var(--bg-surface);
   color: var(--text-color);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Два бага веб-интерфейса, оба про переключатель языка на странице логина: **SOFT-7355** и **SOFT-7354**. Срочные — на неделе проверка на аккредитацию, где ПО должно демонстрировать полный перевод на русский, а интерфейс при первой загрузке открывался на английском.

**SOFT-7355.** Определение языка сравнивало `navigator.language` буквально со списком локалей прошивки, а список содержит голые первичные сабтеги (`en`, `ru`, `kk`, `it`, `de`). Браузер по BCP 47 отдаёт тег с регионом — `ru-RU`, `de-AT`, `it-CH`, `kk-KZ` — поэтому точное сравнение промахивалось на любом регионализованном браузере и сразу откатывалось на английский, хотя русский перевод был полным всё это время. Вдобавок читался только `navigator.language`, а `navigator.languages` — упорядоченный список предпочтений и настоящий источник истины — игнорировался.

**SOFT-7354.** Переключатель языка на логине — нативный `<select>` на тёмной панели, со стилем `.login-lang:hover { color: #fff }`. Правила для `option` в проекте не было нигде, а Chromium позволяет `<option>` наследовать `color` от своего `<select>`; пока список раскрыт, курсор физически стоит на самом контроле, то есть `:hover` активен всё это время. Все пункты рисовались белым по светлому нативному listbox — читалась только строка под подсветкой. Причина в тикете была помечена как неизвестная.

___________________________________
**Что поменялось для пользователей:**

- **Интерфейс открывается на языке браузера.** Русский браузер — русский интерфейс с первой загрузки, без ручного выбора. Тем же изменением чинятся немецкий, итальянский и казахский с региональными тегами: баг был не про русский, а про любой тег с регионом.
- **Учитывается весь список предпочтений браузера по порядку**, а не только первый язык: если первым стоит неподдерживаемый, берётся следующий поддерживаемый.
- **Пункты списка языков на логине читаемы всегда**, а не только под курсором. Свёрнутый переключатель выглядит ровно как раньше — приглушённый серый текст без рамки и фона поверх градиента панели.
- **Явный выбор языка по-прежнему главнее браузера**, но устаревшее или руками правленое сохранённое значение больше не запирает интерфейс на локали без переводов — вместо этого срабатывает автоопределение.
- **Интерфейс больше не падает целиком, если браузеру запрещено хранилище.** Обращение к `localStorage` происходит на уровне модуля, и там, где сайту запрещены данные сайта, само обращение к свойству кидает `SecurityError` — это обрывало импорт `@/i18n`, то есть UI не открывался вообще, а не просто терял язык. Теперь язык просто не запоминается между перезагрузками.

Форматов настроек, API и протоколов изменение не касается — только фронтенд.

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)

- `npm run test` — 758 тестов, все зелёные; `npm run lint` — чисто; `npm run build` (`vue-tsc -b && vite build`) — чисто.
- **Мутационный тест** на новый набор: в `normalizeTag` временно подменялось точное сравнение на `startsWith` — падает ровно тест `matches a language code exactly rather than by prefix`, остальные остаются зелёными. Это и была слепая зона, которую тест закрывает: префиксное сравнение отдало бы русский носителю `rue`, итальянский — тегу `ita-IT`, а неподдерживаемое сохранённое `english` перебило бы реальное предпочтение браузера.
- CSS проверен в собранном виде: scope-атрибут садится именно на `option` (`.login-lang option[data-v-2c83af05]{...}`), а правило свёрнутого контрола осталось символ в символ прежним. Отсутствие протечки стиля `option` в закрытый `<select>` отдельно проверено скриншотом в headless Chrome.
- Проверено, что второго источника определения языка нет: в прошивке нет ни обработки `Accept-Language`, ни генерации HTML — единственный источник это SPA. Русская локализация страницы логина полная (5 локалей × 7 ключей), то есть ломался ровно выбор языка, а не перевод.

**Осталось проверить на живом устройстве:** воспроизведение обоих тикетов на самом шлюзе — SOFT-7354 заводился в Edge под Windows, а нативный listbox рисуется браузером и ОС, поэтому финальная проверка нужна именно там. Также стоит пройти сценарий из тикета: браузер с русским языком, очищенный для адреса шлюза выбор языка, первая загрузка.

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)

Да — 23 теста в `src/i18n/resolveLocale.test.ts`.

Чтобы это стало возможным, разбор локали вынесен в отдельный модуль `resolveLocale.ts`, не касающийся DOM: юнит-проект vitest работает в `environment: 'node'`, а `index.ts` дёргает `localStorage`/`navigator`/`document` прямо при импорте, поэтому логика внутри него была непокрываемой в принципе.

Покрыто:
- регионализованные теги — `ru-RU`, `de-AT`, `it-CH`, `kk-KZ`; голый `ru` (отсутствие регрессии на пути, который работал и раньше);
- регистр и разделители: `RU-ru`, `DE`, `ru_RU`, тег из одного разделителя;
- нормализация пробелов, пустые и пробельные теги;
- **точное сравнение, а не префиксное** — `rue` и `ita-IT` не должны совпадать, `english` не должен перебивать браузер;
- приоритеты: явный выбор выигрывает у браузера; порядок предпочтений браузера соблюдается; неподдерживаемое сохранённое значение проваливается в автоопределение, а не в дефолт;
- `preferredTags` отдельным блоком: порядок, копия вместо живой ссылки на `navigator.languages`, деградация при пустом/отсутствующем/не-массиве, пустой результат при полном отсутствии данных.

CSS-фикс SOFT-7354 юнит-тестом не покрыт: это рендеринг нативного listbox браузером и ОС, в happy-dom его нет. Проверялся на собранном CSS и скриншотом в headless Chrome (см. выше).

___________________________________
**Известная мелочь на будущее (не в этом PR):**

`Locale` и `SUPPORTED_LANGUAGES` в `resolveLocale.ts` ведутся двумя независимыми списками, а `readonly Locale[]` принимает подмножество объединения. Сегодня они совпадают, но добавив шестую локаль легко получить язык, который переключается и пишется в `localStorage`, однако не переживает перезагрузку, — и сборка с линтом при этом останутся зелёными. Лечится двумя строками (`SUPPORTED_LANGUAGES ... as const` + `type Locale = typeof SUPPORTED_LANGUAGES[number]`), но это изменение типов, и делать его накануне проверки смысла нет.
